### PR TITLE
#36 Incorrect Slot Label Opacity

### DIFF
--- a/hydrogen/src/components/common/grid/Column.vue
+++ b/hydrogen/src/components/common/grid/Column.vue
@@ -38,7 +38,7 @@ export default {
   },
   data() {
     return {
-      mousePos: [0, 0],
+      mousePos: [-999, -999],
       cellStates: [...new Array(24)].map(() => 0),
       isAllAvailable: false,
     };


### PR DESCRIPTION
Fixed that the slot labels are unexpectedly lighted up.

This was caused by bad initialisation of mouse positions as [0, 0], because the slots might be close enough to that initial position when the page is refreshed. Without mouse moving or entering a column, this position will not be updated, and hence incorrect distances between mouse and slots are calculated.

closes #36 