### PR TITLE
#35 Column Context Menu

### DIFF
--- a/hydrogen/src/components/common/grid/Cell.vue
+++ b/hydrogen/src/components/common/grid/Cell.vue
@@ -1,7 +1,6 @@
 <template>
   <div
     class="cell"
-    oncontextmenu="return false;"
     @mousedown="onMouseDown"
     @mouseenter="onMouseEnter"
     :style="{ background: [

--- a/hydrogen/src/components/common/grid/Grid.vue
+++ b/hydrogen/src/components/common/grid/Grid.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class='grid'>
+  <div class='grid' oncontextmenu="return false;">
       <div class='columns'>
         <column
           v-for='idx in 7' :key='idx'


### PR DESCRIPTION
Adjusted context menu hiding granularity.

Now right clicking anywhere on the grid will not bring up the context menu.

closes #35 